### PR TITLE
fix: fixed endpoints

### DIFF
--- a/internal/database/availability.sql.go
+++ b/internal/database/availability.sql.go
@@ -7,7 +7,6 @@ package database
 
 import (
 	"context"
-	"time"
 )
 
 const createAvailability = `-- name: CreateAvailability :one
@@ -15,16 +14,16 @@ INSERT INTO availability (
   doctor_id, day_of_week, start_time, end_time, is_recurring,interval_minutes
 ) VALUES (
   $1, $2, $3, $4, $5,$6
-) RETURNING availability_id, doctor_id, start_time, end_time, is_recurring, specific_date, created_at, updated_at, day_of_week, interval_minutes
+) RETURNING availability_id, doctor_id, start_time, end_time, is_recurring, created_at, updated_at, day_of_week, interval_minutes
 `
 
 type CreateAvailabilityParams struct {
-	DoctorID        int64     `json:"doctor_id"`
-	DayOfWeek       int32     `json:"day_of_week"`
-	StartTime       time.Time `json:"start_time"`
-	EndTime         time.Time `json:"end_time"`
-	IsRecurring     bool      `json:"is_recurring"`
-	IntervalMinutes int32     `json:"interval_minutes"`
+	DoctorID        int64  `json:"doctor_id"`
+	DayOfWeek       int32  `json:"day_of_week"`
+	StartTime       string `json:"start_time"`
+	EndTime         string `json:"end_time"`
+	IsRecurring     bool   `json:"is_recurring"`
+	IntervalMinutes int32  `json:"interval_minutes"`
 }
 
 func (q *Queries) CreateAvailability(ctx context.Context, arg CreateAvailabilityParams) (Availability, error) {
@@ -43,7 +42,6 @@ func (q *Queries) CreateAvailability(ctx context.Context, arg CreateAvailability
 		&i.StartTime,
 		&i.EndTime,
 		&i.IsRecurring,
-		&i.SpecificDate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.DayOfWeek,
@@ -81,7 +79,7 @@ func (q *Queries) DeleteAvailabityById(ctx context.Context, arg DeleteAvailabity
 }
 
 const getAvailabilityByDoctor = `-- name: GetAvailabilityByDoctor :many
-SELECT availability_id, doctor_id, start_time, end_time, is_recurring, specific_date, created_at, updated_at, day_of_week, interval_minutes FROM availability WHERE doctor_id=$1
+SELECT availability_id, doctor_id, start_time, end_time, is_recurring, created_at, updated_at, day_of_week, interval_minutes FROM availability WHERE doctor_id=$1
 `
 
 func (q *Queries) GetAvailabilityByDoctor(ctx context.Context, doctorID int64) ([]Availability, error) {
@@ -99,7 +97,6 @@ func (q *Queries) GetAvailabilityByDoctor(ctx context.Context, doctorID int64) (
 			&i.StartTime,
 			&i.EndTime,
 			&i.IsRecurring,
-			&i.SpecificDate,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DayOfWeek,
@@ -119,7 +116,7 @@ func (q *Queries) GetAvailabilityByDoctor(ctx context.Context, doctorID int64) (
 }
 
 const getAvailabilityByDoctorAndDay = `-- name: GetAvailabilityByDoctorAndDay :many
-SELECT availability_id, doctor_id, start_time, end_time, is_recurring, specific_date, created_at, updated_at, day_of_week, interval_minutes FROM availability WHERE doctor_id=$1 AND day_of_week=$2
+SELECT availability_id, doctor_id, start_time, end_time, is_recurring, created_at, updated_at, day_of_week, interval_minutes FROM availability WHERE doctor_id=$1 AND day_of_week=$2
 `
 
 type GetAvailabilityByDoctorAndDayParams struct {
@@ -142,7 +139,6 @@ func (q *Queries) GetAvailabilityByDoctorAndDay(ctx context.Context, arg GetAvai
 			&i.StartTime,
 			&i.EndTime,
 			&i.IsRecurring,
-			&i.SpecificDate,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DayOfWeek,

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -112,10 +112,9 @@ type Appointment struct {
 type Availability struct {
 	AvailabilityID  int64        `json:"availability_id"`
 	DoctorID        int64        `json:"doctor_id"`
-	StartTime       time.Time    `json:"start_time"`
-	EndTime         time.Time    `json:"end_time"`
+	StartTime       string       `json:"start_time"`
+	EndTime         string       `json:"end_time"`
 	IsRecurring     bool         `json:"is_recurring"`
-	SpecificDate    sql.NullTime `json:"specific_date"`
 	CreatedAt       time.Time    `json:"created_at"`
 	UpdatedAt       sql.NullTime `json:"updated_at"`
 	DayOfWeek       int32        `json:"day_of_week"`

--- a/internal/model/availability.go
+++ b/internal/model/availability.go
@@ -1,12 +1,10 @@
 package model
 
-import "time"
-
 type CreateAvailabilityRequest struct {
-	DayOfWeek       int32     `json:"day_of_week" validate:"required" `
-	StartTime       time.Time `json:"start_time" validate:"required" `
-	EndTime         time.Time `json:"end_time"  validate:"required"`
-	IntervalMinutes int32     `json:"interval_minutes"`
+	DayOfWeek       int32  `json:"day_of_week" validate:"required" `
+	StartTime       string `json:"start_time" validate:"required" `
+	EndTime         string `json:"end_time"  validate:"required"`
+	IntervalMinutes int32  `json:"interval_minutes"`
 
 	// IsRecurring bool      `json:"is_recurring"`
 }

--- a/internal/server/repository/availability_repostitory.go
+++ b/internal/server/repository/availability_repostitory.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"time"
 
 	"github.com/mbeka02/lyra_backend/internal/database"
 )
@@ -10,8 +9,8 @@ import (
 type CreateAvailabilityParams struct {
 	DoctorID        int64
 	DayOfWeek       int32
-	StartTime       time.Time
-	EndTime         time.Time
+	StartTime       string
+	EndTime         string
 	IntervalMinutes int32
 
 	// IsRecurring bool      `json:"is_recurring"`

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -45,9 +45,9 @@ func (s *Server) RegisterRoutes() http.Handler {
 		r.Get("/doctor/availability", s.handlers.Availability.HandleGetAvailabilityByDoctor)
 		r.Post("/doctor", s.handlers.Doctor.HandleCreateDoctor)
 		r.Post("/doctor/availability", s.handlers.Availability.HandleCreateAvailability)
+		r.Delete("/doctor/availability/id/{availabilityId}", s.handlers.Availability.HandleDeleteById)
+		r.Delete("/doctor/availability/day/{dayOfWeek}", s.handlers.Availability.HandleDeleteByDay)
 	})
-	r.Delete("/doctor/availability/id/{availabilityId}", s.handlers.Availability.HandleDeleteById)
-	r.Delete("/doctor/availability/day/{dayOfWeek}", s.handlers.Availability.HandleDeleteByDay)
 	return r
 }
 

--- a/internal/server/service/availability_service.go
+++ b/internal/server/service/availability_service.go
@@ -49,6 +49,16 @@ func (s *availabilityService) CreateAvailability(ctx context.Context, req model.
 	if err != nil {
 		return database.Availability{}, errors.New("unable to get the user details of this account")
 	}
+	// // parse the time
+	// startTime, err := util.ParseTimeFromString(req.StartTime)
+	// if err != nil {
+	// 	return database.Availability{}, errors.New("invalid time format.")
+	// }
+	// endTime, err := util.ParseTimeFromString(req.EndTime)
+	// if err != nil {
+	// 	return database.Availability{}, errors.New("invalid time format.")
+	// }
+	// log.Println(startTime, endTime)
 	return s.availabilityRepo.Create(ctx, repository.CreateAvailabilityParams{
 		DoctorID:        doctorId,
 		StartTime:       req.StartTime,

--- a/internal/util/time.go
+++ b/internal/util/time.go
@@ -1,0 +1,7 @@
+package util
+
+import "time"
+
+func ParseTimeFromString(t string) (time.Time, error) {
+	return time.Parse("15:04:05", t)
+}

--- a/sql/schema/005_avaliability.sql
+++ b/sql/schema/005_avaliability.sql
@@ -5,17 +5,12 @@ doctor_id bigint NOT NULL REFERENCES doctors(doctor_id) ON DELETE CASCADE,
 start_time time NOT NULL,
 end_time time NOT NULL,
 is_recurring boolean NOT NULL DEFAULT true,
-specific_date date,
 created_at timestamptz NOT NULL DEFAULT (now()),
 --TODO: Add a trigger to update this before update
 updated_at timestamptz DEFAULT (now()),
 day_of_week integer NOT NULL CHECK (day_of_week between 0 AND 6),
 interval_minutes integer NOT NULL DEFAULT 60,
-CONSTRAINT valid_time_range CHECK (start_time<end_time),
-CONSTRAINT specific_or_recurring CHECK (
-(is_recurring = true AND specific_date IS NULL) OR
-(is_recurring = false AND specific_date IS NOT NULL)
-)
+CONSTRAINT valid_time_range CHECK (start_time<end_time)
 );
 
 CREATE INDEX idx_availability_doctor_id ON availability(doctor_id);

--- a/sql/schema/006_functions.sql
+++ b/sql/schema/006_functions.sql
@@ -14,17 +14,13 @@ BEGIN
   -- Extract the time and date components from appointment timestamptz
   appt_start_time := NEW.start_time::time;
   appt_end_time := NEW.end_time::time;
-  appt_date := NEW.start_time::date;
   appt_dow := EXTRACT(DOW FROM NEW.start_time); -- This is coming from the appointments table
   -- Check if the time slot exists in doctor's availability
   SELECT EXISTS (
     SELECT 1 FROM availability
     WHERE doctor_id = NEW.doctor_id
-      AND (
-        (is_recurring = true AND day_of_week=appt_dow)
-        OR
-        (is_recurring = false AND specific_date = appt_date)
-      )
+      AND 
+      (is_recurring = true AND day_of_week=appt_dow)
       AND start_time <= appt_start_time
       AND end_time >= appt_end_time
   ) INTO slot_available;

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -7,3 +7,6 @@ sql:
       go:
         out: "internal/database"
         emit_json_tags: true # Add this line to generate JSON tags
+        overrides:
+          - db_type: "pg_catalog.time"
+            go_type: "string"


### PR DESCRIPTION
This pull request includes several changes to the handling of availability data in the database. The most significant changes involve modifying the data types for start and end times, removing the specific date field, and updating related SQL queries and functions.

### Changes to data types and fields:

* [`internal/database/availability.sql.go`](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L10-R24): Changed `StartTime` and `EndTime` from `time.Time` to `string` in `CreateAvailabilityParams` and `Availability` struct, and removed `SpecificDate` field from SQL queries and struct. [[1]](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L10-R24) [[2]](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L46) [[3]](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L84-R82) [[4]](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L102) [[5]](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L122-R119) [[6]](diffhunk://#diff-d5c90a0cdf5b3681d93bce4109c8822b4b3793a327061e55235d875e350caa63L115-L118)

### SQL schema updates:

* [`sql/schema/005_avaliability.sql`](diffhunk://#diff-8f3994ec57417184e9e23420dc2b92f2c9680d783b5b0cb1259baad7926d05ebL8-R13): Removed `specific_date` column and its constraints from the `availability` table schema.
* [`sql/schema/006_functions.sql`](diffhunk://#diff-25d638f66c265f1b6081261fdc41013b7ca66b4ccdf422c14e6f8c4620eaa897L17-L27): Updated function to remove checks for `specific_date` and simplify time slot availability logic.

### Code updates:

* [`internal/model/availability.go`](diffhunk://#diff-379f0a714c9cf4fe16a5200ec8977450e6b9266ac070652b6fb70567aa3ef93aL3-R6): Changed `StartTime` and `EndTime` from `time.Time` to `string` in `CreateAvailabilityRequest`.
* [`internal/server/repository/availability_repostitory.go`](diffhunk://#diff-8b03e99d362d17a02fdb9f567e1210365c3aa094993b4b8e81ee2ce513bd4e94L5-R13): Changed `StartTime` and `EndTime` from `time.Time` to `string` in `CreateAvailabilityParams`.
* [`internal/server/service/availability_service.go`](diffhunk://#diff-2125428de2749af810e72a8b6e1a9c7f6fb1586ec437420a14be1f8bac8defeaR52-R61): Commented out time parsing logic for `StartTime` and `EndTime`.
* [`internal/util/time.go`](diffhunk://#diff-6d44b556af195d36c15862cfce5ddb02dad7782f6a2bdf02a29e25c4025be2f7R1-R7): Added utility function `ParseTimeFromString` to parse time from string.

### Configuration updates:

* [`sqlc.yaml`](diffhunk://#diff-07e9b06d162a323220c7054f3b7e0b19f9354dad428006ce5471cd201890967aR10-R12): Added override to map `pg_catalog.time` to `string` in generated Go code.