### PR TITLE
fix: added default value for the day_of_week

### DIFF
--- a/internal/model/availability.go
+++ b/internal/model/availability.go
@@ -1,7 +1,7 @@
 package model
 
 type CreateAvailabilityRequest struct {
-	DayOfWeek       int32  `json:"day_of_week" validate:"required" `
+	DayOfWeek       int32  `json:"day_of_week" default:"0" `
 	StartTime       string `json:"start_time" validate:"required" `
 	EndTime         string `json:"end_time"  validate:"required"`
 	IntervalMinutes int32  `json:"interval_minutes"`


### PR DESCRIPTION
This pull request includes a change to the `internal/model/availability.go` file. The change modifies the `CreateAvailabilityRequest` struct by removing the validation requirement for the `DayOfWeek` field and setting a default value instead.

* [`internal/model/availability.go`](diffhunk://#diff-379f0a714c9cf4fe16a5200ec8977450e6b9266ac070652b6fb70567aa3ef93aL4-R4): Changed the `DayOfWeek` field in the `CreateAvailabilityRequest` struct to have a default value of `0` and removed the `required` validation.