### PR TITLE
fix for the availability is_recurring field that was being set to fal…

### DIFF
--- a/internal/database/availability.sql.go
+++ b/internal/database/availability.sql.go
@@ -12,9 +12,9 @@ import (
 
 const createAvailability = `-- name: CreateAvailability :one
 INSERT INTO availability (
-  doctor_id, day_of_week, start_time, end_time, is_recurring,interval_minutes
+  doctor_id, day_of_week, start_time, end_time,interval_minutes
 ) VALUES (
-  $1, $2, $3, $4, $5,$6
+  $1, $2, $3, $4, $5
 ) RETURNING availability_id, doctor_id, start_time, end_time, is_recurring, created_at, updated_at, day_of_week, interval_minutes
 `
 
@@ -23,7 +23,6 @@ type CreateAvailabilityParams struct {
 	DayOfWeek       int32  `json:"day_of_week"`
 	StartTime       string `json:"start_time"`
 	EndTime         string `json:"end_time"`
-	IsRecurring     bool   `json:"is_recurring"`
 	IntervalMinutes int32  `json:"interval_minutes"`
 }
 
@@ -33,7 +32,6 @@ func (q *Queries) CreateAvailability(ctx context.Context, arg CreateAvailability
 		arg.DayOfWeek,
 		arg.StartTime,
 		arg.EndTime,
-		arg.IsRecurring,
 		arg.IntervalMinutes,
 	)
 	var i Availability

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -28,7 +28,6 @@ func (s *Server) RegisterRoutes() http.Handler {
 	r.Use(middleware.Logger)
 
 	r.Get("/", s.TestHandler)
-	// TODO: move this to the right place
 
 	r.Get("/health", s.healthHandler)
 	r.Post("/register", s.handlers.User.HandleCreateUser)

--- a/sql/queries/availability.sql
+++ b/sql/queries/availability.sql
@@ -1,8 +1,8 @@
 -- name: CreateAvailability :one
 INSERT INTO availability (
-  doctor_id, day_of_week, start_time, end_time, is_recurring,interval_minutes
+  doctor_id, day_of_week, start_time, end_time,interval_minutes
 ) VALUES (
-  $1, $2, $3, $4, $5,$6
+  $1, $2, $3, $4, $5
 ) RETURNING *;
 -- name: GetAvailabilityByDoctor :many
 SELECT * FROM availability WHERE doctor_id=$1;


### PR DESCRIPTION
This pull request includes several changes to the `availability` feature and a minor update to the server routes. The most important changes involve removing the `is_recurring` field from the `CreateAvailability` function and its related SQL queries.

Changes to `availability` feature:

* [`internal/database/availability.sql.go`](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L15-R17): Removed the `is_recurring` field from the `CreateAvailability` SQL query and the `CreateAvailabilityParams` struct. Updated the `CreateAvailability` function to reflect this change. [[1]](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L15-R17) [[2]](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L26) [[3]](diffhunk://#diff-60f75ddbd80f94b31a3299bab91c965bf81c7b283d965c93dd3353cf603ecfb1L36)
* [`sql/queries/availability.sql`](diffhunk://#diff-573721b4897e5b165392051e0fc5a555932b1b8a4776dc055f6cb59d07d5a290L3-R5): Removed the `is_recurring` field from the `CreateAvailability` SQL query.

Changes to server routes:

* [`internal/server/routes.go`](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640L31): Removed a TODO comment related to route organization.…se instead of true