### PR TITLE
fix:payment amount is now in cents to comply with ISO 4217 standards

### DIFF
--- a/internal/model/payment.go
+++ b/internal/model/payment.go
@@ -3,7 +3,7 @@ package model
 import "time"
 
 type InitializeTransactionRequest struct {
-	Amount            string   `json:"amount" validate:"required"`
+	Amount            int64    `json:"amount" validate:"required"`
 	Email             string   `json:"email" validate:"required,email" `
 	CallBackURL       string   `json:"callback_url,omitempty"` //  Use this to override the callback url provided on the dashboard for this transaction
 	Channels          []string `json:"channels,omitempty"`     // An array of payment channels to control what channels you want to make available to the user to make a payment with.

--- a/internal/server/service/appointment_service.go
+++ b/internal/server/service/appointment_service.go
@@ -73,7 +73,7 @@ func (s *appointmentService) CreateAppointmentWithPayment(ctx context.Context, r
 	amountFloat, err := strconv.ParseFloat(req.Amount, 64)
 	if err != nil {
 		// Handle error
-		return nil, err
+		return nil, fmt.Errorf("failed to parse payment amount as float64")
 	}
 
 	// Multiply by 100 for cents

--- a/internal/server/service/appointment_service.go
+++ b/internal/server/service/appointment_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/mbeka02/lyra_backend/internal/database"
 	"github.com/mbeka02/lyra_backend/internal/model"
@@ -68,10 +69,20 @@ func (s *appointmentService) CreateAppointmentWithPayment(ctx context.Context, r
 	if err != nil {
 		return nil, errors.New("unable to get the user details of this account")
 	}
+	// convert amount to a float64
+	amountFloat, err := strconv.ParseFloat(req.Amount, 64)
+	if err != nil {
+		// Handle error
+		return nil, err
+	}
+
+	// Multiply by 100 for cents
+	amountInCents := int64(amountFloat * 100)
+
 	// send paystack  initialize payment request
 	response, err := s.paymentProcessor.InitializeTransaction(model.InitializeTransactionRequest{
 		Email:  email,
-		Amount: req.Amount,
+		Amount: amountInCents,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("payment processing error:%v", err)


### PR DESCRIPTION
This pull request includes changes to the payment processing system to handle transaction amounts more accurately. The most important changes involve modifying the data type of the `Amount` field and updating the logic for processing payment amounts.

Changes to payment processing:

* [`internal/model/payment.go`](diffhunk://#diff-fea537d54a9fc416c67073c303928f692dd94417563ee903ef3c24213b735679L6-R6): Changed the `Amount` field in `InitializeTransactionRequest` from `string` to `int64` to ensure amounts are handled as integers.
* [`internal/server/service/appointment_service.go`](diffhunk://#diff-9c244dc08d7f9f4a0376b8e0c01a17df5cc72445137444840191da1d847a9213R72-R85): Added logic to convert the `Amount` from a string to a float, multiply by 100 to convert to cents, and then cast to `int64` before sending the payment request.

Additional changes:

* [`internal/server/service/appointment_service.go`](diffhunk://#diff-9c244dc08d7f9f4a0376b8e0c01a17df5cc72445137444840191da1d847a9213R7): Imported the `strconv` package to facilitate the conversion of the `Amount` from a string to a float.