### PR TITLE
Repo pattern

### DIFF
--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -40,7 +40,7 @@ type AuthResponse struct {
 	User           UserResponse `json:"user"`
 }
 
-func NewUserResponse(user database.User) UserResponse {
+func NewUserResponse(user *database.User) UserResponse {
 	return UserResponse{
 		UserId:          user.UserID,
 		Fullname:        user.FullName,

--- a/internal/server/repository/appointment_repository.go
+++ b/internal/server/repository/appointment_repository.go
@@ -45,8 +45,7 @@ type UpdateAppointmentStatusParams struct {
 	Status        string
 }
 type AppointmentRepository interface {
-	Create(ctx context.Context, params CreateAppointmentParams, PatientID int64) (database.Appointment, error)
-	CreateAppointmentWithPayment(ctx context.Context, params CreateAppointmentWithPaymentParams) (CreateAppointmentWithPaymentTxResults, error)
+	CreateAppointmentWithPayment(ctx context.Context, params CreateAppointmentWithPaymentParams) (*CreateAppointmentWithPaymentTxResults, error)
 	GetPatientAppointments(ctx context.Context, params GetPatientAppointmentsParams) ([]database.GetPatientAppointmentsRow, error)
 	GetDoctorAppointments(ctx context.Context, params GetDoctorAppointmentsParams) ([]database.GetDoctorAppointmentsRow, error)
 	GetAppointmentIDs(ctx context.Context, params GetAppointmentIDsParams) ([]int64, error)
@@ -93,7 +92,7 @@ func (r *appointmentRepository) GetPatientAppointments(ctx context.Context, para
 	})
 }
 
-func (r *appointmentRepository) CreateAppointmentWithPayment(ctx context.Context, params CreateAppointmentWithPaymentParams) (CreateAppointmentWithPaymentTxResults, error) {
+func (r *appointmentRepository) CreateAppointmentWithPayment(ctx context.Context, params CreateAppointmentWithPaymentParams) (*CreateAppointmentWithPaymentTxResults, error) {
 	var result CreateAppointmentWithPaymentTxResults
 	err := r.store.ExecTx(ctx, func(q *database.Queries) error {
 		var err error
@@ -119,15 +118,5 @@ func (r *appointmentRepository) CreateAppointmentWithPayment(ctx context.Context
 
 		return err
 	})
-	return result, err
-}
-
-func (r *appointmentRepository) Create(ctx context.Context, params CreateAppointmentParams, PatientID int64) (database.Appointment, error) {
-	return r.store.CreateAppointment(ctx, database.CreateAppointmentParams{
-		DoctorID:  params.DoctorID,
-		PatientID: PatientID,
-		StartTime: params.StartTime,
-		EndTime:   params.EndTime,
-		Reason:    params.Reason,
-	})
+	return &result, err
 }

--- a/internal/server/repository/availability_repostitory.go
+++ b/internal/server/repository/availability_repostitory.go
@@ -22,7 +22,7 @@ type GetSlotsParams struct {
 	SlotDate  time.Time
 }
 type AvailabilityRepository interface {
-	Create(ctx context.Context, params CreateAvailabilityParams) (database.Availability, error)
+	Create(ctx context.Context, params CreateAvailabilityParams) (*database.Availability, error)
 	GetByDoctor(ctx context.Context, doctorId int64) ([]database.Availability, error)
 	GetSlots(ctx context.Context, params GetSlotsParams) ([]database.GetAppointmentSlotsRow, error)
 	DeleteById(ctx context.Context, availabilityId int64, doctorId int64) error
@@ -47,14 +47,18 @@ func (r *availabilityRepository) GetSlots(ctx context.Context, params GetSlotsPa
 	})
 }
 
-func (r *availabilityRepository) Create(ctx context.Context, params CreateAvailabilityParams) (database.Availability, error) {
-	return r.store.CreateAvailability(ctx, database.CreateAvailabilityParams{
+func (r *availabilityRepository) Create(ctx context.Context, params CreateAvailabilityParams) (*database.Availability, error) {
+	availabilitySlot, err := r.store.CreateAvailability(ctx, database.CreateAvailabilityParams{
 		DoctorID:        params.DoctorID,
 		StartTime:       params.StartTime,
 		EndTime:         params.EndTime,
 		DayOfWeek:       params.DayOfWeek,
 		IntervalMinutes: params.IntervalMinutes,
 	})
+	if err != nil {
+		return nil, err
+	}
+	return &availabilitySlot, nil
 }
 
 func (r *availabilityRepository) GetByDoctor(ctx context.Context, DoctorID int64) ([]database.Availability, error) {

--- a/internal/server/repository/doctor_repository.go
+++ b/internal/server/repository/doctor_repository.go
@@ -30,7 +30,7 @@ type GetDoctorsParams struct {
 }
 
 type DoctorRepository interface {
-	Create(context.Context, CreateDoctorParams) (database.Doctor, error)
+	Create(context.Context, CreateDoctorParams) (*database.Doctor, error)
 	GetAllDoctors(context.Context, GetDoctorsParams) ([]database.GetDoctorsRow, error)
 	GetDoctorIdByUserId(context.Context, int64) (int64, error)
 }
@@ -45,7 +45,7 @@ func NewDoctorRepository(store *database.Store) DoctorRepository {
 	}
 }
 
-func (r *doctorRepository) Create(ctx context.Context, params CreateDoctorParams) (database.Doctor, error) {
+func (r *doctorRepository) Create(ctx context.Context, params CreateDoctorParams) (*database.Doctor, error) {
 	var doctor database.Doctor
 	err := r.store.ExecTx(ctx, func(q *database.Queries) error {
 		var err error
@@ -66,7 +66,7 @@ func (r *doctorRepository) Create(ctx context.Context, params CreateDoctorParams
 		err = q.CompleteOnboarding(ctx, params.UserID)
 		return err
 	})
-	return doctor, err
+	return &doctor, err
 }
 
 func (r *doctorRepository) GetDoctorIdByUserId(ctx context.Context, UserID int64) (int64, error) {

--- a/internal/server/repository/patient_repository.go
+++ b/internal/server/repository/patient_repository.go
@@ -19,7 +19,7 @@ type CreatePatientParams struct {
 	EmergencyContactPhone string
 }
 type PatientRepository interface {
-	Create(context.Context, CreatePatientParams) (database.Patient, error)
+	Create(context.Context, CreatePatientParams) (*database.Patient, error)
 	GetPatientIdByUserId(context.Context, int64) (int64, error)
 }
 
@@ -33,7 +33,7 @@ func NewPatientRepository(store *database.Store) PatientRepository {
 	}
 }
 
-func (r *patientRepository) Create(ctx context.Context, params CreatePatientParams) (database.Patient, error) {
+func (r *patientRepository) Create(ctx context.Context, params CreatePatientParams) (*database.Patient, error) {
 	var patient database.Patient
 	err := r.store.ExecTx(ctx, func(q *database.Queries) error {
 		var err error
@@ -57,7 +57,7 @@ func (r *patientRepository) Create(ctx context.Context, params CreatePatientPara
 		err = q.CompleteOnboarding(ctx, params.UserID)
 		return err
 	})
-	return patient, err
+	return &patient, err
 }
 
 func (r *patientRepository) GetPatientIdByUserId(ctx context.Context, UserID int64) (int64, error) {

--- a/internal/server/repository/payment_repository.go
+++ b/internal/server/repository/payment_repository.go
@@ -37,7 +37,6 @@ func (r *paymentRepository) UpdatePaymentAndAppointmentStatus(ctx context.Contex
 			CurrentStatus: database.PaymentStatus(params.PaymentStatus),
 			Reference:     params.Reference,
 		})
-		// NB: MAKE SURE YOU RETURN THE QUERY ERROR AT EACH STAGE OF THE TRANSACTION
 		if err != nil {
 			return err
 		}

--- a/internal/server/repository/user_repository.go
+++ b/internal/server/repository/user_repository.go
@@ -23,9 +23,9 @@ type UpdateUserParams struct {
 	UserId          int64
 }
 type UserRepository interface {
-	Create(ctx context.Context, params CreateUserParams) (database.User, error)
-	GetByEmail(ctx context.Context, email string) (database.User, error)
-	GetById(ctx context.Context, id int64) (database.User, error)
+	Create(ctx context.Context, params CreateUserParams) (*database.User, error)
+	GetByEmail(ctx context.Context, email string) (*database.User, error)
+	GetById(ctx context.Context, id int64) (*database.User, error)
 	Update(ctx context.Context, params UpdateUserParams) error
 	UpdateProfilePicture(ctx context.Context, profilePictureURL string, userId int64) error
 }
@@ -40,8 +40,8 @@ func NewUserRepository(store *database.Store) UserRepository {
 	}
 }
 
-func (r *userRepository) Create(ctx context.Context, params CreateUserParams) (database.User, error) {
-	return r.store.CreateUser(ctx, database.CreateUserParams{
+func (r *userRepository) Create(ctx context.Context, params CreateUserParams) (*database.User, error) {
+	user, err := r.store.CreateUser(ctx, database.CreateUserParams{
 		FullName:        params.FullName,
 		Email:           params.Email,
 		TelephoneNumber: params.TelephoneNumber,
@@ -49,6 +49,10 @@ func (r *userRepository) Create(ctx context.Context, params CreateUserParams) (d
 		UserRole:        params.UserRole,
 		DateOfBirth:     params.DateOfBirth,
 	})
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
 }
 
 func (r *userRepository) Update(ctx context.Context, params UpdateUserParams) error {
@@ -67,10 +71,18 @@ func (r *userRepository) UpdateProfilePicture(ctx context.Context, profilePictur
 	})
 }
 
-func (r *userRepository) GetByEmail(ctx context.Context, email string) (database.User, error) {
-	return r.store.GetUserByEmail(ctx, email)
+func (r *userRepository) GetByEmail(ctx context.Context, email string) (*database.User, error) {
+	user, err := r.store.GetUserByEmail(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+	return &user, err
 }
 
-func (r *userRepository) GetById(ctx context.Context, userId int64) (database.User, error) {
-	return r.store.GetUserById(ctx, userId)
+func (r *userRepository) GetById(ctx context.Context, userId int64) (*database.User, error) {
+	user, err := r.store.GetUserById(ctx, userId)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
 }

--- a/internal/server/service/appointment_service.go
+++ b/internal/server/service/appointment_service.go
@@ -33,7 +33,6 @@ type UpdateAppointmentStatusParams struct {
 }
 
 type AppointmentService interface {
-	CreateAppointment(ctx context.Context, req model.CreateAppointmentRequest, userId int64) (database.Appointment, error)
 	CreateAppointmentWithPayment(ctx context.Context, req model.CreateAppointmentRequest, userId int64, email string) (*model.InitializeTransactionResponse, error)
 
 	GetPatientAppointments(ctx context.Context, params GetAppointmentsParams) ([]database.GetPatientAppointmentsRow, error)
@@ -105,20 +104,6 @@ func (s *appointmentService) GetPatientAppointments(ctx context.Context, params 
 		Status:    params.Status,
 		Interval:  params.Interval,
 	})
-}
-
-func (s *appointmentService) CreateAppointment(ctx context.Context, req model.CreateAppointmentRequest, userId int64) (database.Appointment, error) {
-	patientId, err := s.patientRepo.GetPatientIdByUserId(ctx, userId)
-	if err != nil {
-		return database.Appointment{}, errors.New("error getting the patient info linked to this account")
-	}
-
-	return s.appointmentRepo.Create(ctx, repository.CreateAppointmentParams{
-		DoctorID:  req.DoctorID,
-		StartTime: req.StartTime,
-		EndTime:   req.EndTime,
-		Reason:    req.Reason,
-	}, patientId)
 }
 
 // TODO: CLEAN THIS UP

--- a/internal/server/service/availability_service.go
+++ b/internal/server/service/availability_service.go
@@ -15,7 +15,7 @@ type availabilityService struct {
 }
 
 type AvailabilityService interface {
-	CreateAvailability(ctx context.Context, req model.CreateAvailabilityRequest, userId int64) (database.Availability, error)
+	CreateAvailability(ctx context.Context, req model.CreateAvailabilityRequest, userId int64) (*database.Availability, error)
 	GetAvailabilityByDoctor(ctx context.Context, userId int64) ([]database.Availability, error)
 	GetSlots(ctx context.Context, req model.GetSlotsRequest) ([]database.GetAppointmentSlotsRow, error)
 	DeleteById(ctx context.Context, avavailabilityId int64, userId int64) error
@@ -53,21 +53,11 @@ func NewAvailabilityService(availabilityRepo repository.AvailabilityRepository, 
 	}
 }
 
-func (s *availabilityService) CreateAvailability(ctx context.Context, req model.CreateAvailabilityRequest, userId int64) (database.Availability, error) {
+func (s *availabilityService) CreateAvailability(ctx context.Context, req model.CreateAvailabilityRequest, userId int64) (*database.Availability, error) {
 	doctorId, err := s.doctorRepo.GetDoctorIdByUserId(ctx, userId)
 	if err != nil {
-		return database.Availability{}, errors.New("unable to get the user details of this account")
+		return nil, errors.New("unable to get the user details of this account")
 	}
-	// // parse the time
-	// startTime, err := util.ParseTimeFromString(req.StartTime)
-	// if err != nil {
-	// 	return database.Availability{}, errors.New("invalid time format.")
-	// }
-	// endTime, err := util.ParseTimeFromString(req.EndTime)
-	// if err != nil {
-	// 	return database.Availability{}, errors.New("invalid time format.")
-	// }
-	// log.Println(startTime, endTime)
 
 	return s.availabilityRepo.Create(ctx, repository.CreateAvailabilityParams{
 		DoctorID:        doctorId,

--- a/internal/server/service/doctor_service.go
+++ b/internal/server/service/doctor_service.go
@@ -10,7 +10,7 @@ import (
 )
 
 type DoctorService interface {
-	CreateDoctor(ctx context.Context, req model.CreateDoctorRequest, userId int64) (database.Doctor, error)
+	CreateDoctor(ctx context.Context, req model.CreateDoctorRequest, userId int64) (*database.Doctor, error)
 	GetDoctors(ctx context.Context, county, specialization, minPrice, maxPrice, sortBy, sortOrder string, minExperience, maxExpreinece, limit, offset int32) (model.GetDoctorsResponse, error)
 }
 type doctorService struct {
@@ -23,7 +23,7 @@ func NewDoctorService(doctorRepo repository.DoctorRepository) DoctorService {
 	}
 }
 
-func (s *doctorService) CreateDoctor(ctx context.Context, req model.CreateDoctorRequest, userId int64) (database.Doctor, error) {
+func (s *doctorService) CreateDoctor(ctx context.Context, req model.CreateDoctorRequest, userId int64) (*database.Doctor, error) {
 	return s.doctorRepo.Create(ctx, repository.CreateDoctorParams{
 		Specialization:    req.Specialization,
 		LicenseNumber:     req.LicenseNumber,

--- a/internal/server/service/patient_service.go
+++ b/internal/server/service/patient_service.go
@@ -13,7 +13,7 @@ type patientService struct {
 }
 
 type PatientService interface {
-	CreatePatient(ctx context.Context, req model.CreatePatientRequest, userId int64) (database.Patient, error)
+	CreatePatient(ctx context.Context, req model.CreatePatientRequest, userId int64) (*database.Patient, error)
 }
 
 func NewPatientService(patientRepo repository.PatientRepository) PatientService {
@@ -22,7 +22,7 @@ func NewPatientService(patientRepo repository.PatientRepository) PatientService 
 	}
 }
 
-func (s *patientService) CreatePatient(ctx context.Context, req model.CreatePatientRequest, userId int64) (database.Patient, error) {
+func (s *patientService) CreatePatient(ctx context.Context, req model.CreatePatientRequest, userId int64) (*database.Patient, error) {
 	return s.patientRepo.Create(ctx, repository.CreatePatientParams{
 		UserID:                userId,
 		Allergies:             req.Allergies,

--- a/internal/server/service/user_service.go
+++ b/internal/server/service/user_service.go
@@ -64,7 +64,6 @@ func NewUserService(
 	}
 }
 
-// TODO:make the return value a ptr
 func (s *userService) CreateUser(ctx context.Context, req model.CreateUserRequest) (model.AuthResponse, error) {
 	passwordHash, err := auth.HashPassword(req.Password)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces a significant refactor across multiple repositories and services, transitioning return values from structs to pointers for consistency and improved error handling. The changes primarily affect the creation and retrieval methods in repositories and services, ensuring they now return pointers to the respective types. Additionally, some redundant methods and comments have been removed for code clarity.

### Repository Changes
* Updated repository interfaces and methods to return pointers instead of structs for consistency and better error handling:
  - `CreateAppointmentWithPayment` in `appointment_repository` now returns a pointer to `CreateAppointmentWithPaymentTxResults` (`[[1]](diffhunk://#diff-1cf34834fc35b7dce684a956e8d2e1dc07295a2ecefae0cc2e651ed54846bba3L48-R48)`, `[[2]](diffhunk://#diff-1cf34834fc35b7dce684a956e8d2e1dc07295a2ecefae0cc2e651ed54846bba3L96-R95)`, `[[3]](diffhunk://#diff-1cf34834fc35b7dce684a956e8d2e1dc07295a2ecefae0cc2e651ed54846bba3L122-R121)`).
  - `Create` methods in `availability_repository`, `doctor_repository`, `patient_repository`, and `user_repository` now return pointers to their respective types (`[[1]](diffhunk://#diff-8b03e99d362d17a02fdb9f567e1210365c3aa094993b4b8e81ee2ce513bd4e94L25-R25)`, `F8fb3321L23R23`, `[[2]](diffhunk://#diff-8360929b40437a87e887cae2a6659e72fbcdf8ad03b5ced068ea2774209065b2L22-R22)`, `[[3]](diffhunk://#diff-6377f6d20dedeefb88742cd4abbc4970a0ee2f8271005a5a2da246d9b5b0154cL26-R28)`).
  - Retrieval methods like `GetByEmail` and `GetById` in `user_repository` now return pointers (`[internal/server/repository/user_repository.goL70-R87](diffhunk://#diff-6377f6d20dedeefb88742cd4abbc4970a0ee2f8271005a5a2da246d9b5b0154cL70-R87)`).

### Service Changes
* Updated service methods to align with repository changes, ensuring they return pointers:
  - `CreateAvailability` in `availability_service` now returns a pointer to `database.Availability` (`[[1]](diffhunk://#diff-2125428de2749af810e72a8b6e1a9c7f6fb1586ec437420a14be1f8bac8defeaL18-R18)`, `[[2]](diffhunk://#diff-2125428de2749af810e72a8b6e1a9c7f6fb1586ec437420a14be1f8bac8defeaL56-L70)`).
  - `CreateDoctor` in `doctor_service` now returns a pointer to `database.Doctor` (`[[1]](diffhunk://#diff-7b34e328906ac75a7a647d8b7ac62d1dfabb4570c4d132dbe176d8de27ff78deL13-R13)`, `[[2]](diffhunk://#diff-7b34e328906ac75a7a647d8b7ac62d1dfabb4570c4d132dbe176d8de27ff78deL26-R26)`).
  - `CreatePatient` in `patient_service` now returns a pointer to `database.Patient` (`[[1]](diffhunk://#diff-b67f11930b2410765f804903a8cd44e185be08d3753fea719ca3be67dd874268L16-R16)`, `[[2]](diffhunk://#diff-b67f11930b2410765f804903a8cd44e185be08d3753fea719ca3be67dd874268L25-R25)`).

### Code Cleanup
* Removed the unused `CreateAppointment` method from `appointment_service` and its related repository implementation (`[[1]](diffhunk://#diff-9c244dc08d7f9f4a0376b8e0c01a17df5cc72445137444840191da1d847a9213L36)`, `[[2]](diffhunk://#diff-9c244dc08d7f9f4a0376b8e0c01a17df5cc72445137444840191da1d847a9213L110-L123)`).
* Removed a redundant comment in `payment_repository` regarding transaction error handling (`[internal/server/repository/payment_repository.goL40](diffhunk://#diff-2896576952e7795abb5f71eec913dac0f622a379419efdd46fd6408867102df1L40)`).

These changes improve the codebase's consistency, reduce memory overhead, and enhance error handling by allowing `nil` to represent the absence of a value.